### PR TITLE
Add web UI for configuring charger commands via RabbitMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# AI
-Project Test For AI
+# Command Charger UI
+
+A lightweight web interface for composing and publishing charger configuration commands to the RabbitMQ exchange `evmswss_command`.
+
+## Getting Started
+
+1. Ensure the RabbitMQ Management API is reachable. By default the application targets:
+   - Host: `10.101.1.35`
+   - Port: `15672`
+   - User: `administrator`
+   - Password: `EVEFT@tc`
+   - Exchange: `evmswss_command`
+   - VHost: `/`
+
+   These can be overridden with environment variables (`RABBITMQ_HOST`, `RABBITMQ_HTTP_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, `RABBITMQ_EXCHANGE`, `RABBITMQ_VHOST`).
+
+2. Install Node.js 18+ (Node 20 LTS recommended).
+
+3. Start the application:
+
+   ```bash
+   npm start
+   ```
+
+4. Open the interface in your browser at [http://localhost:3000](http://localhost:3000).
+
+## Features
+
+- Guided form for `get_config` and `set_config` commands with automatic JSON preview.
+- Validation for IP address, command type, and key requirements.
+- Optional custom JSON editor when advanced control is needed.
+- One-click copy of the generated JSON payload.
+- Publishes commands to RabbitMQ via the Management HTTP API.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A lightweight web interface for composing and publishing charger configuration c
 ## Getting Started
 
 1. Ensure the RabbitMQ Management API is reachable. By default the application targets:
-   - Host: `10.101.1.35`
+   - Host: `0.0.0.0`
    - Port: `15672`
-   - User: `administrator`
-   - Password: `EVEFT@tc`
-   - Exchange: `evmswss_command`
+   - User: `gust`
+   - Password: `gust`
+   - Exchange: `command`
    - VHost: `/`
 
    These can be overridden with environment variables (`RABBITMQ_HOST`, `RABBITMQ_HTTP_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, `RABBITMQ_EXCHANGE`, `RABBITMQ_VHOST`).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai",
+  "version": "1.0.0",
+  "description": "Project Test For AI",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,288 @@
+const keyNames = [
+  'G_ChargerMode',
+  'G_ServerURL',
+  'G_ServerURL2',
+  'G_MaxCurrent',
+  'G_MaxCurrentC',
+  'G_MaxCurrentD',
+  'G_ChargerID',
+  'G_ChargerRate',
+  'G_CardPin',
+  'G_ChargerLanguage',
+  'G_MaxPower',
+  'G_MaxPowerA',
+  'G_MaxPowerB',
+  'G_MaxPowerC',
+  'G_MaxPowerD',
+  'G_MaxPowerE',
+  'G_MaxPowerF',
+  'G_MaxPowerG',
+  'G_MaxPowerH',
+  'G_ChargerNetIP',
+  'G_ChargerNetGateway',
+  'G_ChargerNetMac',
+  'G_ChargerNetMask',
+  'G_ChargerNetDNS',
+  'G_Authentication',
+  'G_MaxTemperature',
+  'G_ChargerType',
+  'UserPassword',
+  'UserPassword2',
+  'G_ChargerSN',
+  'G_DSPVerA',
+  'G_DSPVerB',
+  'G_SECCVerA',
+  'G_SECCVerB',
+  'G_LCD_SCREEN',
+  'EvccMacB',
+  'EvccMacA',
+  'G_HearbeatInterval',
+  'G_WebSocketPingInterval',
+  'G_MeterValueInterval',
+  'AdminPassword',
+  'G_LowTemperature',
+  'G_InsInChargingEnable',
+  'G_RemoteControlGroup',
+  'G_RemoteStartGroup',
+];
+
+const ipInput = document.getElementById('ipaddress');
+const commandInputs = Array.from(document.querySelectorAll('input[name="command"]'));
+const keySelect = document.getElementById('key_name');
+const keyValueInput = document.getElementById('key_value');
+const customToggle = document.getElementById('customToggle');
+const jsonOutput = document.getElementById('jsonOutput');
+const form = document.getElementById('commandForm');
+const feedback = document.getElementById('feedback');
+const copyButton = document.getElementById('copyJson');
+
+const IP_PATTERN = /^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}$/;
+
+function populateKeyNames() {
+  const fragment = document.createDocumentFragment();
+  keyNames.forEach((name) => {
+    const option = document.createElement('option');
+    option.value = name;
+    option.textContent = name;
+    fragment.appendChild(option);
+  });
+  keySelect.appendChild(fragment);
+}
+
+function getSelectedCommand() {
+  const selected = commandInputs.find((input) => input.checked);
+  return selected ? selected.value : 'get_config';
+}
+
+function isCustomMode() {
+  return customToggle.checked;
+}
+
+function setKeyValueState(command) {
+  const shouldEnable = command === 'set_config' && !isCustomMode();
+  keyValueInput.disabled = !shouldEnable;
+  if (!shouldEnable && command !== 'set_config') {
+    keyValueInput.value = '';
+  }
+}
+
+function setFormInteractivity() {
+  const custom = isCustomMode();
+  [ipInput, keySelect, keyValueInput, ...commandInputs].forEach((element) => {
+    if (element === keyValueInput) {
+      setKeyValueState(getSelectedCommand());
+    } else {
+      element.disabled = custom;
+    }
+  });
+  if (!custom) {
+    setKeyValueState(getSelectedCommand());
+  }
+  jsonOutput.readOnly = !custom;
+  jsonOutput.classList.toggle('editable', custom);
+}
+
+function buildGuidedPayload() {
+  const ip = ipInput.value.trim();
+  const command = getSelectedCommand();
+  const key = keySelect.value;
+  const keyValue = keyValueInput.value.trim();
+
+  if (!IP_PATTERN.test(ip)) {
+    return { error: 'กรุณากรอก IP Address ให้ถูกต้อง (เช่น 10.101.1.35).' };
+  }
+
+  if (!key) {
+    return { error: 'กรุณาเลือก Key name.' };
+  }
+
+  if (command === 'set_config' && keyValue.length === 0) {
+    return { error: 'ต้องกรอก key_value เมื่อเลือก set_config.' };
+  }
+
+  const payload = {
+    charger: {
+      ipaddress: ip,
+      command,
+      key_name: key,
+    },
+  };
+
+  if (command === 'set_config') {
+    payload.charger.key_value = keyValue;
+  }
+
+  return { payload };
+}
+
+function updateJsonPreview() {
+  if (isCustomMode()) {
+    return;
+  }
+  const { payload, error } = buildGuidedPayload();
+  if (error) {
+    jsonOutput.value = error;
+    return;
+  }
+  jsonOutput.value = JSON.stringify(payload, null, 2);
+}
+
+function displayFeedback(message, type = 'neutral') {
+  feedback.textContent = message || '';
+  feedback.className = `feedback${type !== 'neutral' ? ` ${type}` : ''}`;
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  displayFeedback('กำลังส่งคำสั่ง...', 'neutral');
+
+  let body;
+
+  if (isCustomMode()) {
+    const raw = jsonOutput.value.trim();
+    if (!raw) {
+      displayFeedback('กรุณาระบุ JSON ที่ต้องการส่ง', 'error');
+      return;
+    }
+    try {
+      JSON.parse(raw);
+    } catch (error) {
+      displayFeedback('รูปแบบ JSON ไม่ถูกต้อง', 'error');
+      return;
+    }
+    body = {
+      mode: 'custom',
+      payload: raw,
+    };
+  } else {
+    const { payload, error } = buildGuidedPayload();
+    if (error) {
+      displayFeedback(error, 'error');
+      return;
+    }
+    body = {
+      mode: 'guided',
+      fields: {
+        ipaddress: payload.charger.ipaddress,
+        command: payload.charger.command,
+        key_name: payload.charger.key_name,
+        key_value: payload.charger.key_value,
+      },
+    };
+  }
+
+  try {
+    const response = await fetch('/api/send-command', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const result = await response.json();
+    if (!response.ok || !result.success) {
+      const message = result.error || 'ไม่สามารถส่งคำสั่งได้';
+      displayFeedback(message, 'error');
+      return;
+    }
+
+    const renderedPayload = JSON.stringify(result.payload, null, 2);
+    if (!isCustomMode()) {
+      jsonOutput.value = renderedPayload;
+    }
+    displayFeedback('ส่งคำสั่งสำเร็จ (routed: ' + result.routed + ')', 'success');
+  } catch (error) {
+    console.error(error);
+    displayFeedback('เกิดข้อผิดพลาดในการเชื่อมต่อกับเซิร์ฟเวอร์', 'error');
+  }
+}
+
+function handleCopy() {
+  const text = jsonOutput.value.trim();
+  if (!text) {
+    displayFeedback('ไม่มีข้อมูลสำหรับคัดลอก', 'error');
+    return;
+  }
+  if (!navigator.clipboard) {
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const succeeded = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      if (succeeded) {
+        displayFeedback('คัดลอก JSON แล้ว', 'success');
+      } else {
+        displayFeedback('ไม่สามารถคัดลอกได้', 'error');
+      }
+    } catch (error) {
+      displayFeedback('ไม่สามารถคัดลอกได้', 'error');
+    }
+    return;
+  }
+  navigator.clipboard
+    .writeText(text)
+    .then(() => displayFeedback('คัดลอก JSON แล้ว', 'success'))
+    .catch(() => displayFeedback('ไม่สามารถคัดลอกได้', 'error'));
+}
+
+populateKeyNames();
+updateJsonPreview();
+setFormInteractivity();
+
+form.addEventListener('submit', handleSubmit);
+commandInputs.forEach((input) => {
+  input.addEventListener('change', () => {
+    setKeyValueState(getSelectedCommand());
+    updateJsonPreview();
+  });
+});
+
+[ipInput, keySelect, keyValueInput].forEach((element) => {
+  element.addEventListener('input', updateJsonPreview);
+});
+
+customToggle.addEventListener('change', () => {
+  const custom = isCustomMode();
+  setFormInteractivity();
+  if (!custom) {
+    updateJsonPreview();
+    return;
+  }
+  try {
+    JSON.parse(jsonOutput.value);
+  } catch (error) {
+    const { payload, error: buildError } = buildGuidedPayload();
+    if (!buildError && payload) {
+      jsonOutput.value = JSON.stringify(payload, null, 2);
+    } else {
+      jsonOutput.value = '';
+    }
+  }
+});
+
+copyButton.addEventListener('click', handleCopy);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Command Charger Sent To RabbitMQ</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <section class="card">
+        <h1>Command Charger Sent To RabbitMQ</h1>
+        <form id="commandForm" class="form">
+          <div class="form-row">
+            <label class="form-label" for="ipaddress">IP</label>
+            <input
+              id="ipaddress"
+              name="ipaddress"
+              type="text"
+              class="form-input"
+              placeholder="10.101.1.xxx"
+              required
+            />
+          </div>
+
+          <fieldset class="form-row">
+            <legend class="form-label">Command</legend>
+            <label class="radio-option">
+              <input type="radio" name="command" value="set_config" />
+              <span>set_config</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="command" value="get_config" checked />
+              <span>get_config</span>
+            </label>
+          </fieldset>
+
+          <div class="form-row">
+            <label class="form-label" for="key_name">Key name</label>
+            <select id="key_name" name="key_name" class="form-input"></select>
+          </div>
+
+          <div class="form-row">
+            <label class="form-label" for="key_value">key_value</label>
+            <div class="input-with-note">
+              <input
+                id="key_value"
+                name="key_value"
+                type="text"
+                class="form-input"
+                placeholder="ต้องระบุเมื่อเลือก set_config"
+                disabled
+              />
+              <small class="note">* ต้องระบุกรณีเลือก set_config</small>
+            </div>
+          </div>
+
+          <div class="form-row checkbox-row">
+            <label class="checkbox">
+              <input type="checkbox" id="customToggle" />
+              <span>Custom</span>
+            </label>
+          </div>
+
+          <div class="form-row textarea-row">
+            <label class="form-label" for="jsonOutput">JSON Preview</label>
+            <textarea
+              id="jsonOutput"
+              class="form-textarea"
+              rows="10"
+              readonly
+            ></textarea>
+            <small class="note">เมื่อเลือก Custom สามารถแก้ไข JSON ได้เอง แต่ต้องเป็นรูปแบบที่กำหนดด้านบน</small>
+          </div>
+
+          <div class="button-row">
+            <button type="button" id="copyJson" class="button secondary">คัดลอก JSON</button>
+            <button type="submit" class="button primary">ส่งคำสั่ง</button>
+          </div>
+        </form>
+        <div id="feedback" role="status" aria-live="polite" class="feedback"></div>
+      </section>
+    </main>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,213 @@
+:root {
+  --bg: #f4f6fb;
+  --card-bg: #ffffff;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --secondary: #64748b;
+  --border: #dbe2ef;
+  --text: #1f2937;
+  --text-muted: #6b7280;
+  --error: #dc2626;
+  --success: #15803d;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.12), transparent 60%),
+    var(--bg);
+  color: var(--text);
+}
+
+.page {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 16px;
+}
+
+.card {
+  width: min(960px, 100%);
+  background-color: var(--card-bg);
+  border-radius: 24px;
+  padding: 40px 48px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 32px;
+  text-align: center;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: 24px;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-weight: 600;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.form-input,
+.form-textarea,
+select {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 16px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  background-color: #f9fafb;
+}
+
+.form-input:focus,
+.form-textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background-color: #ffffff;
+}
+
+.fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.radio-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 24px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.radio-option input[type='radio'] {
+  accent-color: var(--primary);
+}
+
+.checkbox-row {
+  align-items: center;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.checkbox input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+
+.input-with-note {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.note {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.textarea-row .note {
+  margin-top: 4px;
+}
+
+.form-textarea {
+  min-height: 200px;
+  resize: vertical;
+}
+
+.button-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: 12px 24px;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 16px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #ffffff;
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.25);
+}
+
+.button.secondary {
+  background: rgba(100, 116, 139, 0.15);
+  color: var(--secondary);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: inset 0 2px 8px rgba(15, 23, 42, 0.15);
+}
+
+.feedback {
+  margin-top: 24px;
+  min-height: 24px;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.feedback.success {
+  color: var(--success);
+}
+
+.feedback.error {
+  color: var(--error);
+}
+
+@media (max-width: 768px) {
+  .card {
+    padding: 32px 24px;
+  }
+
+  h1 {
+    font-size: 24px;
+  }
+
+  .button-row {
+    justify-content: center;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,323 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const DEFAULT_PORT = Number.parseInt(process.env.PORT, 10) || 3000;
+const HTTP_PROTOCOL = process.env.RABBITMQ_HTTP_PROTOCOL || 'http';
+const RABBIT_HOST = process.env.RABBITMQ_HOST || process.env.RABBITMQ_HTTP_HOST || '10.101.1.35';
+const RABBIT_PORT = Number.parseInt(process.env.RABBITMQ_HTTP_PORT, 10) || 15672;
+const RABBIT_USER = process.env.RABBITMQ_USER || 'administrator';
+const RABBIT_PASS = process.env.RABBITMQ_PASSWORD || process.env.RABBITMQ_PASS || 'EVEFT@tc';
+const RABBIT_EXCHANGE = process.env.RABBITMQ_EXCHANGE || 'evmswss_command';
+const RABBIT_VHOST = process.env.RABBITMQ_VHOST || '/';
+
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const ALLOWED_KEY_NAMES = new Set([
+  'G_ChargerMode',
+  'G_ServerURL',
+  'G_ServerURL2',
+  'G_MaxCurrent',
+  'G_MaxCurrentC',
+  'G_MaxCurrentD',
+  'G_ChargerID',
+  'G_ChargerRate',
+  'G_CardPin',
+  'G_ChargerLanguage',
+  'G_MaxPower',
+  'G_MaxPowerA',
+  'G_MaxPowerB',
+  'G_MaxPowerC',
+  'G_MaxPowerD',
+  'G_MaxPowerE',
+  'G_MaxPowerF',
+  'G_MaxPowerG',
+  'G_MaxPowerH',
+  'G_ChargerNetIP',
+  'G_ChargerNetGateway',
+  'G_ChargerNetMac',
+  'G_ChargerNetMask',
+  'G_ChargerNetDNS',
+  'G_Authentication',
+  'G_MaxTemperature',
+  'G_ChargerType',
+  'UserPassword',
+  'UserPassword2',
+  'G_ChargerSN',
+  'G_DSPVerA',
+  'G_DSPVerB',
+  'G_SECCVerA',
+  'G_SECCVerB',
+  'G_LCD_SCREEN',
+  'EvccMacB',
+  'EvccMacA',
+  'G_HearbeatInterval',
+  'G_WebSocketPingInterval',
+  'G_MeterValueInterval',
+  'AdminPassword',
+  'G_LowTemperature',
+  'G_InsInChargingEnable',
+  'G_RemoteControlGroup',
+  'G_RemoteStartGroup',
+]);
+
+function isValidIpAddress(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const pattern = /^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}$/;
+  return pattern.test(value);
+}
+
+function validateCommand(command) {
+  return command === 'get_config' || command === 'set_config';
+}
+
+function buildPayloadFromFields(fields) {
+  const errors = [];
+  const { ipaddress, command, key_name: keyName, key_value: keyValue } = fields || {};
+
+  if (!isValidIpAddress(ipaddress)) {
+    errors.push('IP address is invalid.');
+  }
+
+  if (!validateCommand(command)) {
+    errors.push('Command must be either "get_config" or "set_config".');
+  }
+
+  if (!ALLOWED_KEY_NAMES.has(keyName)) {
+    errors.push('Key name is not in the allowed list.');
+  }
+
+  if (command === 'set_config' && (keyValue === undefined || keyValue === null || String(keyValue).trim() === '')) {
+    errors.push('Key value is required when using set_config.');
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  const payload = {
+    charger: {
+      ipaddress,
+      command,
+      key_name: keyName,
+    },
+  };
+
+  if (command === 'set_config') {
+    payload.charger.key_value = keyValue;
+  }
+
+  return { payload };
+}
+
+function isObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function validatePayloadStructure(data) {
+  if (!isObject(data) || !isObject(data.charger)) {
+    return 'Payload must be a JSON object with a "charger" object.';
+  }
+  const { charger } = data;
+  const { ipaddress, command, key_name: keyName } = charger;
+
+  if (!isValidIpAddress(ipaddress)) {
+    return 'Invalid IP address in payload.';
+  }
+  if (!validateCommand(command)) {
+    return 'Invalid command in payload.';
+  }
+  if (!ALLOWED_KEY_NAMES.has(keyName)) {
+    return 'Invalid key name in payload.';
+  }
+  if (command === 'set_config') {
+    if (!('key_value' in charger) || String(charger.key_value).trim() === '') {
+      return 'Payload for set_config must include a non-empty key_value.';
+    }
+  }
+  return null;
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => {
+      chunks.push(chunk);
+      if (Buffer.concat(chunks).length > 1_000_000) {
+        reject(new Error('Payload too large.'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res, statusCode, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendNotFound(res) {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Not found');
+}
+
+function getContentType(extension) {
+  switch (extension) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.ico':
+      return 'image/x-icon';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function publishToRabbit(payload) {
+  const url = `${HTTP_PROTOCOL}://${RABBIT_HOST}:${RABBIT_PORT}/api/exchanges/${encodeURIComponent(RABBIT_VHOST)}/${encodeURIComponent(RABBIT_EXCHANGE)}/publish`;
+  const body = {
+    routing_key: '',
+    payload: JSON.stringify(payload),
+    payload_encoding: 'string',
+    properties: {
+      content_type: 'application/json',
+    },
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${Buffer.from(`${RABBIT_USER}:${RABBIT_PASS}`).toString('base64')}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`RabbitMQ publish failed: ${response.status} ${response.statusText} - ${text}`);
+  }
+
+  const result = await response.json();
+  return result;
+}
+
+async function handleSendCommand(req, res) {
+  try {
+    const rawBody = await readRequestBody(req);
+    let body;
+    try {
+      body = JSON.parse(rawBody);
+    } catch (error) {
+      return sendJson(res, 400, { error: 'Request body must be valid JSON.' });
+    }
+
+    const { mode, payload, fields } = body || {};
+
+    let message;
+
+    if (mode === 'custom') {
+      if (typeof payload !== 'string') {
+        return sendJson(res, 400, { error: 'Custom payload must be a JSON string.' });
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(payload);
+      } catch (error) {
+        return sendJson(res, 400, { error: 'Custom payload is not valid JSON.' });
+      }
+      const validationError = validatePayloadStructure(parsed);
+      if (validationError) {
+        return sendJson(res, 400, { error: validationError });
+      }
+      message = parsed;
+    } else {
+      const { payload: builtPayload, errors } = buildPayloadFromFields(fields);
+      if (errors && errors.length > 0) {
+        return sendJson(res, 400, { error: errors.join(' ') });
+      }
+      message = builtPayload;
+    }
+
+    const publishResult = await publishToRabbit(message);
+
+    return sendJson(res, 200, {
+      success: true,
+      routed: publishResult.routed,
+      payload: message,
+    });
+  } catch (error) {
+    console.error('Failed to send command:', error);
+    return sendJson(res, 500, { error: 'Failed to send command to RabbitMQ.', detail: error.message });
+  }
+}
+
+function serveStaticFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        return sendNotFound(res);
+      }
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Internal Server Error');
+      return;
+    }
+    const extension = path.extname(filePath);
+    res.writeHead(200, { 'Content-Type': getContentType(extension) });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = new URL(req.url, `${req.headers['x-forwarded-proto'] || 'http'}://${req.headers.host}`);
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/api/send-command') {
+    handleSendCommand(req, res);
+    return;
+  }
+
+  if (req.method === 'GET') {
+    let relativePath = decodeURIComponent(parsedUrl.pathname);
+    if (relativePath === '/') {
+      relativePath = '/index.html';
+    }
+
+    const sanitizedPath = path.normalize(relativePath).replace(/^\.\.(\/|\\|$)/, '');
+    const filePath = path.join(PUBLIC_DIR, sanitizedPath);
+
+    if (!filePath.startsWith(PUBLIC_DIR)) {
+      sendNotFound(res);
+      return;
+    }
+
+    serveStaticFile(res, filePath);
+    return;
+  }
+
+  res.writeHead(405, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Method Not Allowed');
+});
+
+server.listen(DEFAULT_PORT, () => {
+  console.log(`Server listening on http://localhost:${DEFAULT_PORT}`);
+});


### PR DESCRIPTION
## Summary
- create a lightweight Node HTTP server that validates charger commands and publishes them to the RabbitMQ `evmswss_command` exchange via the Management API
- add a single-page form with guided and custom JSON modes, live preview, and copy support for charger command payloads
- document default RabbitMQ connection details and app usage instructions in the README

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68ca7eda512c8333ae643a38a9b5c878