### PR TITLE
Fix indicator handle usage in USDJPY EA modules

### DIFF
--- a/mql5/EA_USDJPY/EA_USDJPY.mq5
+++ b/mql5/EA_USDJPY/EA_USDJPY.mq5
@@ -1,0 +1,271 @@
+//+------------------------------------------------------------------+
+//| Expert Advisor: EA_USDJPY                                         |
+//| Purpose : Conservative auto-trading on USDJPY only                |
+//| WARNING: ห้ามใช้จริงโดยไม่ทดสอบ Forward/Backtest อย่างละเอียด |
+//+------------------------------------------------------------------+
+#property copyright ""
+#property link      ""
+#property version   "1.00"
+#property strict
+
+#include <Trade\Trade.mqh>
+#include "modules/Utils.mqh"
+#include "modules/Logger.mqh"
+#include "modules/Regime.mqh"
+#include "modules/Signals.mqh"
+#include "modules/RiskManager.mqh"
+#include "modules/TradeManager.mqh"
+#include "modules/NewsFilter.mqh"
+
+//--- input parameters
+input group "=== System ==="
+input int    InpMagic = 17001;
+input bool   InpAllowLong = true;
+input bool   InpAllowShort = true;
+input bool   InpOneTradePerBar = true;
+
+input group "=== Risk Management ==="
+input double InpRiskPerTradePct = 0.5;
+input double InpDailyLossPctCap = 2.0;
+input int    InpMaxPositions = 1;
+
+input group "=== Filters ==="
+input bool   InpUseNewsFilter = false;
+input int    InpNewsBufferMinBefore = 30;
+input int    InpNewsBufferMinAfter  = 30;
+input double InpMaxSpreadPips = 2.0;
+
+input group "=== Regime & Signals ==="
+input int    InpFastMA = 50;
+input int    InpSlowMA = 200;
+input int    InpADX    = 14;
+input double InpADXThreshold = 18.0;
+input int    InpRSI    = 14;
+input int    InpBBPeriod = 20;
+input double InpBBDev    = 2.0;
+
+input group "=== Stops / Targets ==="
+input double InpATRPeriod = 14;
+input double InpSL_ATR_Mult = 2.0;
+input double InpTP_RR       = 1.5;
+input bool   InpUseATRTrailing = true;
+input double InpTrail_ATR_Mult = 1.5;
+
+input group "=== Time Window (Server Time) ==="
+input bool   InpUseTimeWindow = true;
+input int    InpStartHour = 6;
+input int    InpEndHour   = 22;
+
+input group "=== Strategy Mode ==="
+enum ENUM_STRATEGY_MODE { MODE_AUTO=0, MODE_TREND_ONLY, MODE_MEAN_ONLY };
+input ENUM_STRATEGY_MODE InpStrategyMode = MODE_AUTO;
+
+//--- global objects
+CLogger        g_logger;
+CRiskManager   g_risk;
+CTradeManager  g_trade_manager;
+CSignalEngine  g_signals;
+CRegimeDetector g_regime;
+CNewsFilter    g_news;
+Utils::CBarState g_bar_state;
+
+//--- statistics structure
+struct TradeStats
+  {
+   int total_trades;
+   int wins;
+   int losses;
+   double total_rr;
+   double max_drawdown;
+   double peak_equity;
+
+   TradeStats():total_trades(0),wins(0),losses(0),total_rr(0.0),max_drawdown(0.0),peak_equity(0.0){}
+  };
+
+TradeStats g_stats;
+
+//+------------------------------------------------------------------+
+//| Perform initialization checks                                     |
+//+------------------------------------------------------------------+
+bool SelfTest()
+  {
+   if(_Symbol!="USDJPY")
+     {
+      g_logger.Error("SelfTest","Symbol must be USDJPY");
+      return(false);
+     }
+
+   if(!SymbolSelect(_Symbol,true))
+     {
+      g_logger.Error("SelfTest","Failed to select symbol");
+      return(false);
+     }
+
+   double point=SymbolInfoDouble(_Symbol,SYMBOL_POINT);
+   double pip=Utils::PipSize(_Symbol);
+   if(point<=0.0 || pip<=0.0)
+     {
+      g_logger.Error("SelfTest","Invalid point/pip size");
+      return(false);
+     }
+
+   double vol_min=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_MIN);
+   double vol_max=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_MAX);
+   double vol_step=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_STEP);
+   if(vol_min<=0.0 || vol_max<=0.0 || vol_step<=0.0)
+     {
+      g_logger.Error("SelfTest","Volume specification invalid");
+      return(false);
+     }
+
+   double margin=AccountInfoDouble(ACCOUNT_MARGIN_FREE);
+   if(margin<=0.0)
+     {
+      g_logger.Warn("SelfTest","Margin free is non-positive");
+     }
+
+   g_logger.Info("SelfTest","Initialization OK");
+   return(true);
+  }
+
+//+------------------------------------------------------------------+
+//| Initialize Expert                                                 |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   g_logger.Init("EA_USDJPY_log.csv",true);
+   g_logger.Info("Init","Starting EA_USDJPY");
+
+   if(!SelfTest())
+      return(INIT_FAILED);
+
+   g_risk.Configure(_Symbol,&g_logger,InpRiskPerTradePct,InpDailyLossPctCap,InpMaxPositions);
+   g_trade_manager.Configure(_Symbol,&g_risk,&g_logger,InpMaxSpreadPips,InpOneTradePerBar);
+   if(!g_regime.Configure(_Symbol,_Period,InpFastMA,InpSlowMA,InpADX,InpADXThreshold))
+     {
+      g_logger.Error("Init","Failed to configure regime detector");
+      return(INIT_FAILED);
+     }
+   if(!g_signals.Configure(_Symbol,_Period,InpRSI,InpBBPeriod,InpBBDev,InpADX,InpADXThreshold,InpFastMA,InpSlowMA,(int)InpATRPeriod))
+     {
+      g_logger.Error("Init","Failed to configure signal engine");
+      return(INIT_FAILED);
+     }
+   g_news.Configure(InpUseNewsFilter,InpNewsBufferMinBefore,InpNewsBufferMinAfter,&g_logger);
+
+   g_stats.peak_equity=AccountInfoDouble(ACCOUNT_EQUITY);
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Deinitialization                                                  |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+  {
+   g_logger.Info("Deinit","Shutting down EA",IntegerToString(reason));
+   g_logger.Shutdown();
+  }
+
+//+------------------------------------------------------------------+
+//| Main tick handler                                                 |
+//+------------------------------------------------------------------+
+void OnTick()
+  {
+   if(Symbol()!="USDJPY")
+      return;
+
+   g_risk.UpdateDay();
+
+   if(g_risk.IsDailyLossCapHit())
+      return;
+
+   if(!Utils::IsWithinTimeWindow(InpUseTimeWindow,InpStartHour,InpEndHour))
+      return;
+
+   if(InpUseNewsFilter && g_news.ShouldBlock(TimeCurrent()))
+      return;
+
+   TradeSignal signal;
+   ENUM_MARKET_REGIME regime=REGIME_UNKNOWN;
+
+   if(InpStrategyMode==MODE_TREND_ONLY)
+      regime=REGIME_TREND;
+   else if(InpStrategyMode==MODE_MEAN_ONLY)
+      regime=REGIME_MEAN_REVERSION;
+   else
+      regime=g_regime.Detect();
+
+   if(regime==REGIME_TREND)
+      signal=g_signals.GenerateTrendSignal(InpAllowLong,InpAllowShort,InpSL_ATR_Mult,InpTP_RR,InpUseATRTrailing,InpTrail_ATR_Mult);
+   else if(regime==REGIME_MEAN_REVERSION)
+      signal=g_signals.GenerateMeanSignal(InpAllowLong,InpAllowShort,InpSL_ATR_Mult,InpTP_RR,InpUseATRTrailing,InpTrail_ATR_Mult,true);
+
+   if(signal.direction!=SIGNAL_NONE)
+     {
+      if(g_trade_manager.Execute(signal,InpSL_ATR_Mult,InpTrail_ATR_Mult,InpUseATRTrailing,(ulong)InpMagic))
+         g_logger.Info("Signal","Trade executed",EnumToString(regime));
+     }
+
+   if(InpUseATRTrailing)
+     {
+      double atr_for_trailing=g_signals.LatestATR();
+      if(atr_for_trailing>0.0)
+         g_trade_manager.UpdateTrailing(atr_for_trailing,InpTrail_ATR_Mult,(ulong)InpMagic);
+     }
+  }
+
+//+------------------------------------------------------------------+
+//| Handle trade transactions for stats                               |
+//+------------------------------------------------------------------+
+void OnTradeTransaction(const MqlTradeTransaction &trans,const MqlTradeRequest &request,const MqlTradeResult &result)
+  {
+   if(trans.type==TRADE_TRANSACTION_DEAL_ADD)
+     {
+      datetime from=TimeCurrent()-86400*5;
+      datetime to=TimeCurrent();
+      if(!HistorySelect(from,to))
+         return;
+      ulong deal_ticket=trans.deal;
+      if(!HistoryDealSelect(deal_ticket))
+         return;
+      if(HistoryDealGetString(deal_ticket,DEAL_SYMBOL)!=_Symbol)
+         return;
+      double profit=HistoryDealGetDouble(deal_ticket,DEAL_PROFIT)+HistoryDealGetDouble(deal_ticket,DEAL_SWAP)+HistoryDealGetDouble(deal_ticket,DEAL_COMMISSION);
+      double volume=HistoryDealGetDouble(deal_ticket,DEAL_VOLUME);
+      if(volume>0.0)
+        {
+         g_stats.total_trades++;
+         if(profit>0.0)
+            g_stats.wins++;
+         else if(profit<0.0)
+            g_stats.losses++;
+         double risk_amount=AccountInfoDouble(ACCOUNT_EQUITY)*(InpRiskPerTradePct/100.0);
+         if(risk_amount>0.0)
+            g_stats.total_rr+=profit/risk_amount;
+        }
+     }
+
+   double equity=AccountInfoDouble(ACCOUNT_EQUITY);
+   if(equity>g_stats.peak_equity)
+      g_stats.peak_equity=equity;
+   double drawdown=((g_stats.peak_equity-equity)/g_stats.peak_equity)*100.0;
+   if(drawdown>g_stats.max_drawdown)
+      g_stats.max_drawdown=drawdown;
+  }
+
+//+------------------------------------------------------------------+
+//| Provide summary statistics                                        |
+//+------------------------------------------------------------------+
+double OnTester()
+  {
+   g_logger.Info("Tester","Trades",IntegerToString(g_stats.total_trades));
+   g_logger.Info("Tester","Wins",IntegerToString(g_stats.wins));
+   g_logger.Info("Tester","Losses",IntegerToString(g_stats.losses));
+   if(g_stats.total_trades>0)
+     {
+      double avg_rr=g_stats.total_rr/g_stats.total_trades;
+      g_logger.Info("Tester","Average R:R",DoubleToString(avg_rr,2));
+     }
+   g_logger.Info("Tester","Max Drawdown %",DoubleToString(g_stats.max_drawdown,2));
+   return(g_stats.max_drawdown);
+  }

--- a/mql5/EA_USDJPY/README.md
+++ b/mql5/EA_USDJPY/README.md
@@ -1,0 +1,105 @@
+# EA_USDJPY – Expert Advisor เพื่อความปลอดภัยระยะยาวบน USDJPY
+
+> **คำเตือน**: ห้ามนำ EA นี้ไปใช้งานจริงโดยไม่ทำการ Backtest และ Forward Test อย่างละเอียด พร้อมปรับความเสี่ยงให้เหมาะสมกับพอร์ตของคุณ
+
+## ภาพรวม
+EA_USDJPY ถูกออกแบบให้เทรดเฉพาะคู่เงิน USDJPY โดยให้ความสำคัญกับการจำกัดความเสี่ยงในแต่ละดีลและทั้งวันเป็นอันดับแรก ตัวระบบประกอบด้วยโมดูลย่อยที่แบ่งหน้าที่ชัดเจน ทำให้ง่ายต่อการอ่าน ทดสอบ และปรับแต่งเพิ่มเติม
+
+## โครงสร้างไฟล์
+```
+mql5/EA_USDJPY/
+├── EA_USDJPY.mq5               // ไฟล์หลักของ EA
+├── modules/
+│   ├── Logger.mqh              // ระบบบันทึก log
+│   ├── NewsFilter.mqh          // ฟิลเตอร์ข่าว (โครงสำหรับต่อยอด)
+│   ├── Regime.mqh              // วิเคราะห์สภาวะตลาด Trend/Range
+│   ├── RiskManager.mqh         // คำนวณความเสี่ยงต่อดีลและควบคุม Daily Loss
+│   ├── Signals.mqh             // เงื่อนไขสัญญาณเข้าออกสองโหมด
+│   ├── TradeManager.mqh        // จัดการคำสั่ง ซื้อ/ขาย/Trail
+│   └── Utils.mqh               // ฟังก์ชันอรรถประโยชน์ เช่น PipSize, TimeWindow
+└── sample_log.csv              // ตัวอย่างรูปแบบ Log CSV
+```
+
+## วิธีติดตั้ง
+1. เปิด MetaTrader 5 และไปที่ `File > Open Data Folder`
+2. คัดลอกโฟลเดอร์ `mql5/EA_USDJPY` ทั้งชุดไปยัง `MQL5/Experts/EA_USDJPY`
+3. เปิด MetaEditor 5 แล้วทำการคอมไพล์ไฟล์ `EA_USDJPY.mq5`
+4. ลาก EA ไปใส่กราฟ `USDJPY` เท่านั้นและตรวจสอบว่าอนุญาต Algo Trading
+
+## การตั้งค่าหลัก (Inputs)
+- **System**
+  - `InpMagic`: Magic Number เฉพาะของ EA
+  - `InpAllowLong / InpAllowShort`: เปิด/ปิดฝั่ง Buy หรือ Sell
+  - `InpOneTradePerBar`: ป้องกันไม่ให้เปิดซ้ำภายในแท่งเดียว
+- **Risk Management**
+  - `InpRiskPerTradePct`: % ของ Equity ที่ยอมเสี่ยงต่อดีล
+  - `InpDailyLossPctCap`: % ขาดทุนต่อวันที่ยอมรับ (หยุดเทรดเมื่อแตะ)
+  - `InpMaxPositions`: จำนวนโพสิชั่นเปิดพร้อมกันสูงสุด (แนะนำ 1)
+- **Filters**
+  - `InpUseNewsFilter`: เปิดใช้ตัวกรองข่าว (ปัจจุบันเป็น Stub)
+  - `InpMaxSpreadPips`: ไม่เทรดเมื่อสเปรดสูงกว่าค่านี้
+- **Regime & Signals**
+  - พารามิเตอร์ของ MA/ADX/RSI/Bollinger เพื่อตรวจจับสภาวะตลาด
+  - `InpStrategyMode`: โหมดทดสอบ – Auto / Trend Only / Mean-Only
+- **Stops / Targets**
+  - `InpSL_ATR_Mult`, `InpTP_RR`: ตั้งค่า SL/TP จาก ATR
+  - `InpUseATRTrailing`: ใช้ Trail SL จาก ATR หรือไม่
+- **Time Window**
+  - กำหนดชั่วโมงที่อนุญาตให้ EA ทำงาน
+
+## กลยุทธ์โดยสรุป
+- **Regime Filter**: แยกระหว่างช่วงแนวโน้ม (Trend) และแกว่งตัว (Mean Reversion) โดยดูจาก MA50/200 และค่า ADX
+- **Trend Mode**: เทรดตามทิศที่ MA จัดเรียง + ADX สูงกว่าค่ากำหนด และมีสัญญาณ Pullback
+- **Mean Reversion Mode**: ใช้ Bollinger Bands + RSI + ATR เพื่อหาจุดกลับตัวในกรอบราคา และเลี่ยงเมื่อ ADX สูง (เทรนด์แรง)
+- **Risk**: คำนวณ Lot จากเปอร์เซ็นต์ความเสี่ยงที่ตั้งไว้ ควบคุมยอดขาดทุนรวมต่อวัน และป้องกันการเปิดซ้ำหลายโพสิชั่น
+
+## การทดสอบ Backtest / Forward Test
+1. เปิด Strategy Tester และเลือก EA_USDJPY บนกราฟ `USDJPY`
+2. เลือกโหมด `Every tick based on real ticks` เพื่อความแม่นยำ
+3. ตั้ง `InpStrategyMode` เป็น `MODE_AUTO` เพื่อให้ EA เลือกโหมดตาม Regime
+4. สำหรับการทดสอบเฉพาะสถานการณ์:
+   - เทรนด์อย่างเดียว: เลือก `MODE_TREND_ONLY`
+   - แกว่งตัวอย่างเดียว: เลือก `MODE_MEAN_ONLY`
+5. ช่วงเวลาที่แนะนำสำหรับ Backtest: H1 หรือ M15 พร้อม Spread ที่สมจริง
+6. หลังจบ Backtest ตรวจสอบผลใน Journal (สถิติรวมจะถูก Log ผ่าน Logger)
+7. Forward Test บนบัญชีเดโม่อย่างน้อย 4–6 สัปดาห์เพื่อยืนยันเสถียรภาพ
+
+## โปรไฟล์ความเสี่ยงที่แนะนำ
+| โปรไฟล์ | InpRiskPerTradePct | InpDailyLossPctCap | InpMaxPositions |
+|---------|--------------------|--------------------|-----------------|
+| ปลอดภัยมาก | 0.25 | 1.0 | 1 |
+| ปกติ | 0.50 | 2.0 | 1 |
+| เชิงรุก (ยังคงปลอดภัย) | 0.70 | 2.0 | 1 |
+
+> ปรับเวลาเทรดและค่าสเปรดสูงสุดให้เหมาะสมกับโบรกเกอร์ของคุณ โดยเฉพาะช่วง Tokyo/London overlap ซึ่งให้สภาพคล่องดีที่สุดสำหรับ USDJPY
+
+## การเชื่อมต่อ News Filter (แนวทางต่อยอด)
+- ปัจจุบัน `NewsFilter.mqh` เป็นโครงสร้างให้สามารถเชื่อมต่อไฟล์ CSV หรือ API ภายนอกได้ในอนาคต
+- เมื่อพร้อมใช้งาน ให้ปรับให้เมธอด `ShouldBlock()` คืนค่า `true` เมื่อเข้าโซนข่าวแรง (ภายในเวลาบัฟเฟอร์ก่อน/หลัง)
+
+## ตัวอย่างผล Log CSV
+ดูรูปแบบในไฟล์ `sample_log.csv`
+```
+timestamp,event,message,extra
+2024-03-01 08:00:01,INFO,Init,Starting EA
+2024-03-01 09:15:02,INFO,Signal,Trade executed|REGIME_TREND
+2024-03-01 10:45:00,WARN,RiskManager,Daily loss cap reached|2.10
+```
+
+## การวิเคราะห์ผลหลังเทรด
+- ตรวจสอบค่าเฉลี่ย R:R และ Max Drawdown จาก Logger
+- เทียบจำนวน Win/Loss กับความเสี่ยงต่อดีลที่ตั้งไว้
+- หาก Daily Loss Cap ถูกทริกเกอร์บ่อย ให้ลดความเสี่ยงต่อดีลหรือปรับ Time Window
+
+## ข้อควรระวังสำหรับผู้พัฒนา
+- ระบบนี้ไม่รองรับการเฉลี่ยขาดทุนหรือ Martingale ทุกกรณี
+- หากต้องเพิ่มคุณสมบัติใหม่ ให้รักษาโครงสร้างโมดูลเดิมเพื่อความง่ายในการทดสอบ
+- ใช้ `HistorySelect` ให้ครอบคลุมช่วงเวลาที่ต้องการก่อนอ่านประวัติคำสั่ง
+
+## พารามิเตอร์แนะนำสำหรับ USDJPY
+- Timeframe: H1 (สามารถลอง M30/M15)
+- `InpMaxSpreadPips`: 2.0 หรือต่ำกว่า
+- `InpStartHour = 6`, `InpEndHour = 22` (ปรับตามเวลาเซิร์ฟเวอร์โบรกเกอร์)
+- `InpUseATRTrailing = true` พร้อม `InpTrail_ATR_Mult = 1.5`
+
+> **จำอีกครั้ง**: ความเสี่ยงอยู่ที่คุณ ผู้พัฒนาจะไม่รับผิดชอบความเสียหายจากการใช้งานจริง

--- a/mql5/EA_USDJPY/modules/Logger.mqh
+++ b/mql5/EA_USDJPY/modules/Logger.mqh
@@ -1,0 +1,114 @@
+#property strict
+
+#ifndef __LOGGER_MQH__
+#define __LOGGER_MQH__
+
+//+------------------------------------------------------------------+
+//| Simple logger writing to Experts tab and optional CSV file       |
+//+------------------------------------------------------------------+
+class CLogger
+  {
+private:
+   int    m_handle;
+   bool   m_file_enabled;
+   string m_file_name;
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CLogger():m_handle(INVALID_HANDLE),m_file_enabled(false),m_file_name(""){}
+
+   //+------------------------------------------------------------------+
+   //| Initialize logger with optional file output                      |
+   //+------------------------------------------------------------------+
+   bool Init(const string file_name,const bool enable_file)
+     {
+      m_file_name=file_name;
+      m_file_enabled=false;
+      if(enable_file)
+        {
+         int handle=FileOpen(m_file_name,FILE_WRITE|FILE_READ|FILE_CSV|FILE_SHARE_READ|FILE_COMMON);
+         if(handle==INVALID_HANDLE)
+           {
+            PrintFormat("[EA] Failed to open log file %s, error=%d",m_file_name,_LastError);
+            return(false);
+           }
+         if(FileSize(handle)==0)
+           {
+            FileWrite(handle,"timestamp","level","event","message","extra");
+           }
+         FileSeek(handle,0,SEEK_END);
+         m_handle=handle;
+         m_file_enabled=true;
+        }
+      else
+        {
+         m_handle=INVALID_HANDLE;
+        }
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Log informational message                                        |
+   //+------------------------------------------------------------------+
+   void Info(const string event,const string message,const string extra="")
+     {
+      string text=StringFormat("[INFO] %s | %s",event,message);
+      if(extra!="")
+         text=StringFormat("%s | %s",text,extra);
+      Print(text);
+      WriteFile("INFO",event,message,extra);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Log warning message                                              |
+   //+------------------------------------------------------------------+
+   void Warn(const string event,const string message,const string extra="")
+     {
+      string text=StringFormat("[WARN] %s | %s",event,message);
+      if(extra!="")
+         text=StringFormat("%s | %s",text,extra);
+      Print(text);
+      WriteFile("WARN",event,message,extra);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Log error message                                                |
+   //+------------------------------------------------------------------+
+   void Error(const string event,const string message,const string extra="")
+     {
+      string text=StringFormat("[ERROR] %s | %s",event,message);
+      if(extra!="")
+         text=StringFormat("%s | %s",text,extra);
+      Print(text);
+      WriteFile("ERROR",event,message,extra);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Internal helper storing structured data                          |
+   //+------------------------------------------------------------------+
+   void WriteFile(const string level,const string event,const string message,const string extra)
+     {
+      if(!m_file_enabled || m_handle==INVALID_HANDLE)
+         return;
+      string time_str=TimeToString(TimeCurrent(),TIME_DATE|TIME_SECONDS);
+      FileWrite(m_handle,time_str,level,event,message,extra);
+      FileFlush(m_handle);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Close file handle                                                |
+   //+------------------------------------------------------------------+
+   void Shutdown()
+     {
+      if(m_handle!=INVALID_HANDLE)
+        {
+         FileFlush(m_handle);
+         FileClose(m_handle);
+         m_handle=INVALID_HANDLE;
+        }
+      m_file_enabled=false;
+     }
+  };
+
+#endif // __LOGGER_MQH__

--- a/mql5/EA_USDJPY/modules/NewsFilter.mqh
+++ b/mql5/EA_USDJPY/modules/NewsFilter.mqh
@@ -1,0 +1,53 @@
+#property strict
+
+#ifndef __NEWS_FILTER_MQH__
+#define __NEWS_FILTER_MQH__
+
+#include "Logger.mqh"
+
+//+------------------------------------------------------------------+
+//| Stub news filter to be integrated with external feeds later      |
+//+------------------------------------------------------------------+
+class CNewsFilter
+  {
+private:
+   bool     m_enabled;
+   int      m_buffer_before;
+   int      m_buffer_after;
+   CLogger *m_logger;
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CNewsFilter():m_enabled(false),m_buffer_before(30),m_buffer_after(30),m_logger(NULL){}
+
+   //+------------------------------------------------------------------+
+   //| Configure filter                                                 |
+   //+------------------------------------------------------------------+
+   void Configure(const bool enabled,const int buffer_before,const int buffer_after,CLogger *logger)
+     {
+      m_enabled=enabled;
+      m_buffer_before=buffer_before;
+      m_buffer_after=buffer_after;
+      m_logger=logger;
+     }
+
+   //+------------------------------------------------------------------+
+   //| Determine whether trading should be blocked                     |
+   //+------------------------------------------------------------------+
+   bool ShouldBlock(const datetime now)
+     {
+      if(!m_enabled)
+         return(false);
+      // Placeholder: integrate with calendar feed via CSV/API later
+      static datetime last_notice=0;
+      if(m_logger!=NULL && (now-last_notice)>300)
+        {
+         m_logger.Warn("NewsFilter","No news source configured - trading paused");
+         last_notice=now;
+        }
+      return(true);
+     }
+  };
+
+#endif // __NEWS_FILTER_MQH__

--- a/mql5/EA_USDJPY/modules/Regime.mqh
+++ b/mql5/EA_USDJPY/modules/Regime.mqh
@@ -1,0 +1,137 @@
+#property strict
+
+#ifndef __REGIME_MQH__
+#define __REGIME_MQH__
+
+//+------------------------------------------------------------------+
+//| Enumeration describing possible trading regimes                  |
+//+------------------------------------------------------------------+
+enum ENUM_MARKET_REGIME
+  {
+   REGIME_UNKNOWN=0,
+   REGIME_TREND,
+   REGIME_MEAN_REVERSION
+  };
+
+//+------------------------------------------------------------------+
+//| Regime detector encapsulating moving averages and ADX logic       |
+//+------------------------------------------------------------------+
+class CRegimeDetector
+  {
+private:
+   string           m_symbol;
+   ENUM_TIMEFRAMES  m_tf;
+   int              m_fast;
+   int              m_slow;
+   int              m_adx_period;
+   double           m_adx_threshold;
+   int              m_handle_ma_fast;
+   int              m_handle_ma_slow;
+   int              m_handle_adx;
+
+   bool CopyValue(const int handle,const int buffer,double &value) const
+     {
+      if(handle==INVALID_HANDLE)
+         return(false);
+      double data[1];
+      if(CopyBuffer(handle,buffer,0,1,data)!=1)
+         return(false);
+      value=data[0];
+      return(true);
+     }
+
+   void Release()
+     {
+      if(m_handle_ma_fast!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_ma_fast);
+      if(m_handle_ma_slow!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_ma_slow);
+      if(m_handle_adx!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_adx);
+      m_handle_ma_fast=INVALID_HANDLE;
+      m_handle_ma_slow=INVALID_HANDLE;
+      m_handle_adx=INVALID_HANDLE;
+     }
+
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CRegimeDetector():m_symbol(""),m_tf(PERIOD_H1),m_fast(50),m_slow(200),m_adx_period(14),m_adx_threshold(20.0),
+                     m_handle_ma_fast(INVALID_HANDLE),m_handle_ma_slow(INVALID_HANDLE),m_handle_adx(INVALID_HANDLE){}
+
+   //+------------------------------------------------------------------+
+   //| Destructor                                                       |
+   //+------------------------------------------------------------------+
+   ~CRegimeDetector()
+     {
+      Release();
+     }
+
+   //+------------------------------------------------------------------+
+   //| Initialize internal settings                                     |
+   //+------------------------------------------------------------------+
+   bool Configure(const string symbol,const ENUM_TIMEFRAMES tf,const int fast,const int slow,const int adx_period,const double adx_threshold)
+     {
+      Release();
+      m_symbol=symbol;
+      m_tf=tf;
+      m_fast=fast;
+      m_slow=slow;
+      m_adx_period=adx_period;
+      m_adx_threshold=adx_threshold;
+
+      m_handle_ma_fast=iMA(m_symbol,m_tf,m_fast,0,MODE_EMA,PRICE_CLOSE);
+      m_handle_ma_slow=iMA(m_symbol,m_tf,m_slow,0,MODE_EMA,PRICE_CLOSE);
+      m_handle_adx=iADX(m_symbol,m_tf,m_adx_period);
+
+      if(m_handle_ma_fast==INVALID_HANDLE || m_handle_ma_slow==INVALID_HANDLE || m_handle_adx==INVALID_HANDLE)
+        {
+         Release();
+         return(false);
+        }
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Determine active trading regime                                  |
+   //+------------------------------------------------------------------+
+   ENUM_MARKET_REGIME Detect() const
+     {
+      if(m_symbol=="" || m_handle_ma_fast==INVALID_HANDLE)
+         return(REGIME_UNKNOWN);
+
+      double ma_fast=0.0,ma_slow=0.0,adx_main=0.0;
+      if(!CopyValue(m_handle_ma_fast,0,ma_fast) || !CopyValue(m_handle_ma_slow,0,ma_slow) || !CopyValue(m_handle_adx,0,adx_main))
+         return(REGIME_UNKNOWN);
+
+      if(ma_fast==0.0 || ma_slow==0.0)
+         return(REGIME_UNKNOWN);
+
+      if(adx_main>=m_adx_threshold && MathAbs(ma_fast-ma_slow)>(SymbolInfoDouble(m_symbol,SYMBOL_POINT)*10.0))
+         return(REGIME_TREND);
+
+      return(REGIME_MEAN_REVERSION);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Convenience helpers exposing slope and relation                  |
+   //+------------------------------------------------------------------+
+   bool IsBullTrend() const
+     {
+      double ma_fast=0.0,ma_slow=0.0;
+      if(!CopyValue(m_handle_ma_fast,0,ma_fast) || !CopyValue(m_handle_ma_slow,0,ma_slow))
+         return(false);
+      return(ma_fast>ma_slow);
+     }
+
+   bool IsBearTrend() const
+     {
+      double ma_fast=0.0,ma_slow=0.0;
+      if(!CopyValue(m_handle_ma_fast,0,ma_fast) || !CopyValue(m_handle_ma_slow,0,ma_slow))
+         return(false);
+      return(ma_fast<ma_slow);
+     }
+  };
+
+#endif // __REGIME_MQH__

--- a/mql5/EA_USDJPY/modules/RiskManager.mqh
+++ b/mql5/EA_USDJPY/modules/RiskManager.mqh
@@ -1,0 +1,137 @@
+#property strict
+
+#ifndef __RISK_MANAGER_MQH__
+#define __RISK_MANAGER_MQH__
+
+#include "Utils.mqh"
+#include "Logger.mqh"
+
+//+------------------------------------------------------------------+
+//| Risk manager maintains per-trade and daily loss limits            |
+//+------------------------------------------------------------------+
+class CRiskManager
+  {
+private:
+   string m_symbol;
+   CLogger *m_logger;
+   double m_daily_loss_cap_pct;
+   double m_risk_per_trade_pct;
+   int    m_max_positions;
+   int     m_current_day;
+   double  m_start_of_day_equity;
+   bool    m_daily_cap_triggered;
+
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CRiskManager():m_symbol(""),m_logger(NULL),m_daily_loss_cap_pct(2.0),m_risk_per_trade_pct(0.5),m_max_positions(1),m_current_day(0),m_start_of_day_equity(0.0),m_daily_cap_triggered(false){}
+
+   //+------------------------------------------------------------------+
+   //| Configure manager                                                |
+   //+------------------------------------------------------------------+
+   void Configure(const string symbol,CLogger *logger,const double risk_pct,const double daily_cap,const int max_positions)
+     {
+      m_symbol=symbol;
+      m_logger=logger;
+      m_risk_per_trade_pct=risk_pct;
+      m_daily_loss_cap_pct=daily_cap;
+      m_max_positions=max_positions;
+      m_current_day=TimeDay(TimeCurrent());
+      m_start_of_day_equity=AccountInfoDouble(ACCOUNT_EQUITY);
+      m_daily_cap_triggered=false;
+     }
+
+   //+------------------------------------------------------------------+
+   //| Reset daily counters on new day                                  |
+   //+------------------------------------------------------------------+
+   void UpdateDay()
+     {
+      datetime now=TimeCurrent();
+      int day=TimeDay(now);
+      if(day!=m_current_day)
+        {
+         m_current_day=day;
+         m_start_of_day_equity=AccountInfoDouble(ACCOUNT_EQUITY);
+         m_daily_cap_triggered=false;
+         if(m_logger!=NULL)
+            m_logger.Info("RiskManager","Reset daily loss cap");
+        }
+     }
+
+   //+------------------------------------------------------------------+
+   //| Evaluate daily loss cap                                          |
+   //+------------------------------------------------------------------+
+   bool IsDailyLossCapHit()
+     {
+      if(m_daily_cap_triggered)
+         return(true);
+      double equity=AccountInfoDouble(ACCOUNT_EQUITY);
+      double decline_percent=((m_start_of_day_equity-equity)/m_start_of_day_equity)*100.0;
+      if(decline_percent>=m_daily_loss_cap_pct)
+        {
+         m_daily_cap_triggered=true;
+         if(m_logger!=NULL)
+            m_logger.Warn("RiskManager","Daily loss cap reached",DoubleToString(decline_percent,2));
+        }
+      return(m_daily_cap_triggered);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Determine if current position count below maximum                |
+   //+------------------------------------------------------------------+
+   bool CanOpenPosition()
+     {
+      if(IsDailyLossCapHit())
+         return(false);
+
+      int total=PositionsTotal();
+      int symbol_positions=0;
+      for(int i=0;i<total;i++)
+        {
+         if(!PositionSelectByIndex(i))
+            continue;
+         if(PositionGetString(POSITION_SYMBOL)==m_symbol)
+            symbol_positions++;
+        }
+      if(symbol_positions>=m_max_positions)
+        {
+         if(m_logger!=NULL)
+            m_logger.Warn("RiskManager","Max positions limit reached",IntegerToString(symbol_positions));
+         return(false);
+        }
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Calculate volume based on risk percentage and stop distance      |
+   //+------------------------------------------------------------------+
+   double CalculateVolume(const double stop_distance_points)
+     {
+      double pip_size=Utils::PipSize(m_symbol);
+      if(pip_size<=0.0 || stop_distance_points<=0.0)
+         return(0.0);
+
+      double risk_amount=AccountInfoDouble(ACCOUNT_EQUITY)*(m_risk_per_trade_pct/100.0);
+      double tick_value=SymbolInfoDouble(m_symbol,SYMBOL_TRADE_TICK_VALUE);
+      double tick_size=SymbolInfoDouble(m_symbol,SYMBOL_TRADE_TICK_SIZE);
+
+      if(tick_value<=0.0 || tick_size<=0.0)
+         return(0.0);
+
+      double per_lot_loss=(stop_distance_points/tick_size)*tick_value;
+      if(per_lot_loss<=0.0)
+         return(0.0);
+
+      double volume=risk_amount/per_lot_loss;
+      return(Utils::NormalizeVolume(m_symbol,volume));
+     }
+
+   //+------------------------------------------------------------------+
+   //| Expose risk settings                                             |
+   //+------------------------------------------------------------------+
+   double RiskPerTradePct() const { return(m_risk_per_trade_pct); }
+   double DailyLossCapPct() const { return(m_daily_loss_cap_pct); }
+  };
+
+#endif // __RISK_MANAGER_MQH__

--- a/mql5/EA_USDJPY/modules/Signals.mqh
+++ b/mql5/EA_USDJPY/modules/Signals.mqh
@@ -1,0 +1,247 @@
+#property strict
+
+#ifndef __SIGNALS_MQH__
+#define __SIGNALS_MQH__
+
+#include "Regime.mqh"
+
+//+------------------------------------------------------------------+
+//| Signal type                                                       |
+//+------------------------------------------------------------------+
+enum ENUM_SIGNAL_DIRECTION
+  {
+   SIGNAL_NONE=0,
+   SIGNAL_LONG,
+   SIGNAL_SHORT
+  };
+
+//+------------------------------------------------------------------+
+//| Structure representing trade signal                               |
+//+------------------------------------------------------------------+
+struct TradeSignal
+  {
+   ENUM_SIGNAL_DIRECTION direction;
+   double entry_price;
+   double stop_price;
+   double target_price;
+   double atr_value;
+   bool   use_trailing;
+
+   TradeSignal():direction(SIGNAL_NONE),entry_price(0.0),stop_price(0.0),target_price(0.0),atr_value(0.0),use_trailing(false){}
+  };
+
+//+------------------------------------------------------------------+
+//| Signal engine combining trend and mean-reversion logic            |
+//+------------------------------------------------------------------+
+class CSignalEngine
+  {
+private:
+   string          m_symbol;
+   ENUM_TIMEFRAMES m_tf;
+   int             m_rsi_period;
+   int             m_bb_period;
+   double          m_bb_dev;
+   int             m_adx_period;
+   double          m_adx_threshold;
+   int             m_fast_ma;
+   int             m_slow_ma;
+   int             m_atr_period;
+
+   int             m_handle_adx;
+   int             m_handle_ma_fast;
+   int             m_handle_ma_slow;
+   int             m_handle_atr;
+   int             m_handle_bbands;
+   int             m_handle_rsi;
+
+   bool CopyValue(const int handle,const int buffer,double &value) const
+     {
+      if(handle==INVALID_HANDLE)
+         return(false);
+      double data[1];
+      if(CopyBuffer(handle,buffer,0,1,data)!=1)
+         return(false);
+      value=data[0];
+      return(true);
+     }
+
+   void Release()
+     {
+      if(m_handle_adx!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_adx);
+      if(m_handle_ma_fast!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_ma_fast);
+      if(m_handle_ma_slow!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_ma_slow);
+      if(m_handle_atr!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_atr);
+      if(m_handle_bbands!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_bbands);
+      if(m_handle_rsi!=INVALID_HANDLE)
+         IndicatorRelease(m_handle_rsi);
+      m_handle_adx=INVALID_HANDLE;
+      m_handle_ma_fast=INVALID_HANDLE;
+      m_handle_ma_slow=INVALID_HANDLE;
+      m_handle_atr=INVALID_HANDLE;
+      m_handle_bbands=INVALID_HANDLE;
+      m_handle_rsi=INVALID_HANDLE;
+     }
+
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CSignalEngine():m_symbol(""),m_tf(PERIOD_H1),m_rsi_period(14),m_bb_period(20),m_bb_dev(2.0),m_adx_period(14),m_adx_threshold(18.0),
+                   m_fast_ma(50),m_slow_ma(200),m_atr_period(14),
+                   m_handle_adx(INVALID_HANDLE),m_handle_ma_fast(INVALID_HANDLE),m_handle_ma_slow(INVALID_HANDLE),
+                   m_handle_atr(INVALID_HANDLE),m_handle_bbands(INVALID_HANDLE),m_handle_rsi(INVALID_HANDLE){}
+
+   ~CSignalEngine()
+     {
+      Release();
+     }
+
+   //+------------------------------------------------------------------+
+   //| Configure signal engine                                          |
+   //+------------------------------------------------------------------+
+   bool Configure(const string symbol,const ENUM_TIMEFRAMES tf,const int rsi_period,const int bb_period,const double bb_dev,
+                  const int adx_period,const double adx_threshold,const int fast_ma,const int slow_ma,const int atr_period)
+     {
+      Release();
+      m_symbol=symbol;
+      m_tf=tf;
+      m_rsi_period=rsi_period;
+      m_bb_period=bb_period;
+      m_bb_dev=bb_dev;
+      m_adx_period=adx_period;
+      m_adx_threshold=adx_threshold;
+      m_fast_ma=fast_ma;
+      m_slow_ma=slow_ma;
+      m_atr_period=atr_period;
+
+      m_handle_adx=iADX(m_symbol,m_tf,m_adx_period);
+      m_handle_ma_fast=iMA(m_symbol,m_tf,m_fast_ma,0,MODE_EMA,PRICE_CLOSE);
+      m_handle_ma_slow=iMA(m_symbol,m_tf,m_slow_ma,0,MODE_EMA,PRICE_CLOSE);
+      m_handle_atr=iATR(m_symbol,m_tf,m_atr_period);
+      m_handle_bbands=iBands(m_symbol,m_tf,m_bb_period,m_bb_dev,0,PRICE_CLOSE);
+      m_handle_rsi=iRSI(m_symbol,m_tf,m_rsi_period,PRICE_CLOSE);
+
+      if(m_handle_adx==INVALID_HANDLE || m_handle_ma_fast==INVALID_HANDLE || m_handle_ma_slow==INVALID_HANDLE ||
+         m_handle_atr==INVALID_HANDLE || m_handle_bbands==INVALID_HANDLE || m_handle_rsi==INVALID_HANDLE)
+        {
+         Release();
+         return(false);
+        }
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Latest ATR value                                                 |
+   //+------------------------------------------------------------------+
+   double LatestATR() const
+     {
+      double value=0.0;
+      if(!CopyValue(m_handle_atr,0,value))
+         return(0.0);
+      return(value);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Generate signal for trend regime                                 |
+   //+------------------------------------------------------------------+
+   TradeSignal GenerateTrendSignal(const bool allow_long,const bool allow_short,const double sl_mult,const double tp_rr,
+                                   const bool use_trail,const double trail_mult) const
+     {
+      TradeSignal signal;
+      if(m_symbol=="")
+         return(signal);
+
+      double adx=0.0,ma_fast=0.0,ma_slow=0.0,atr=0.0;
+      if(!CopyValue(m_handle_adx,0,adx) || !CopyValue(m_handle_ma_fast,0,ma_fast) ||
+         !CopyValue(m_handle_ma_slow,0,ma_slow) || !CopyValue(m_handle_atr,0,atr))
+         return(signal);
+
+      if(adx<m_adx_threshold || ma_fast==0.0 || ma_slow==0.0 || atr<=0.0)
+         return(signal);
+
+      double price_close=iClose(m_symbol,m_tf,0);
+      double prev_high=iHigh(m_symbol,m_tf,1);
+      double prev_low=iLow(m_symbol,m_tf,1);
+      double current_low=iLow(m_symbol,m_tf,0);
+      double current_high=iHigh(m_symbol,m_tf,0);
+
+      if(allow_long && ma_fast>ma_slow && price_close>ma_fast && current_low<=ma_fast && iClose(m_symbol,m_tf,0)>prev_high)
+        {
+         signal.direction=SIGNAL_LONG;
+         signal.entry_price=price_close;
+         signal.atr_value=atr;
+         signal.stop_price=price_close-(atr*sl_mult);
+         signal.target_price=price_close+(atr*sl_mult*tp_rr);
+         signal.use_trailing=use_trail;
+        }
+
+      if(allow_short && ma_fast<ma_slow && price_close<ma_fast && current_high>=ma_fast && iClose(m_symbol,m_tf,0)<prev_low)
+        {
+         signal.direction=SIGNAL_SHORT;
+         signal.entry_price=price_close;
+         signal.atr_value=atr;
+         signal.stop_price=price_close+(atr*sl_mult);
+         signal.target_price=price_close-(atr*sl_mult*tp_rr);
+         signal.use_trailing=use_trail;
+        }
+
+      return(signal);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Generate signal for mean reversion regime                        |
+   //+------------------------------------------------------------------+
+   TradeSignal GenerateMeanSignal(const bool allow_long,const bool allow_short,const double sl_mult,const double tp_rr,
+                                  const bool use_trail,const double trail_mult,const bool avoid_strong_trend) const
+     {
+      TradeSignal signal;
+      if(m_symbol=="")
+         return(signal);
+
+      double bb_mid=0.0,bb_upper=0.0,bb_lower=0.0,rsi=0.0,atr=0.0,adx=0.0;
+      if(!CopyValue(m_handle_bbands,0,bb_mid) || !CopyValue(m_handle_bbands,1,bb_upper) || !CopyValue(m_handle_bbands,2,bb_lower))
+         return(signal);
+      if(!CopyValue(m_handle_rsi,0,rsi) || !CopyValue(m_handle_atr,0,atr))
+         return(signal);
+      if(avoid_strong_trend && !CopyValue(m_handle_adx,0,adx))
+         return(signal);
+
+      if(avoid_strong_trend && adx>=m_adx_threshold)
+         return(signal);
+
+      if(bb_mid==0.0 || atr<=0.0)
+         return(signal);
+
+      double price_close=iClose(m_symbol,m_tf,0);
+      double open_price=iOpen(m_symbol,m_tf,0);
+
+      if(allow_long && price_close<=bb_lower && rsi<30.0 && price_close>open_price)
+        {
+         signal.direction=SIGNAL_LONG;
+         signal.entry_price=price_close;
+         signal.atr_value=atr;
+         signal.stop_price=price_close-(atr*sl_mult);
+         signal.target_price=bb_mid+(atr*tp_rr*0.5);
+         signal.use_trailing=use_trail;
+        }
+
+      if(allow_short && price_close>=bb_upper && rsi>70.0 && price_close<open_price)
+        {
+         signal.direction=SIGNAL_SHORT;
+         signal.entry_price=price_close;
+         signal.atr_value=atr;
+         signal.stop_price=price_close+(atr*sl_mult);
+         signal.target_price=bb_mid-(atr*tp_rr*0.5);
+         signal.use_trailing=use_trail;
+        }
+
+      return(signal);
+     }
+  };
+
+#endif // __SIGNALS_MQH__

--- a/mql5/EA_USDJPY/modules/TradeManager.mqh
+++ b/mql5/EA_USDJPY/modules/TradeManager.mqh
@@ -1,0 +1,219 @@
+#property strict
+
+#ifndef __TRADE_MANAGER_MQH__
+#define __TRADE_MANAGER_MQH__
+
+#include <Trade\Trade.mqh>
+#include "RiskManager.mqh"
+#include "Utils.mqh"
+#include "Logger.mqh"
+
+//+------------------------------------------------------------------+
+//| Trade manager handles execution and trailing logic                |
+//+------------------------------------------------------------------+
+class CTradeManager
+  {
+private:
+   string   m_symbol;
+   CTrade   m_trade;
+   CRiskManager *m_risk;
+   CLogger *m_logger;
+   double   m_max_spread_pips;
+   bool     m_one_trade_per_bar;
+   datetime m_last_trade_bar_time;
+
+public:
+   //+------------------------------------------------------------------+
+   //| Constructor                                                      |
+   //+------------------------------------------------------------------+
+   CTradeManager():m_symbol(""),m_risk(NULL),m_logger(NULL),m_max_spread_pips(2.0),m_one_trade_per_bar(true),m_last_trade_bar_time(0){}
+
+   //+------------------------------------------------------------------+
+   //| Configure trade manager                                          |
+   //+------------------------------------------------------------------+
+   void Configure(const string symbol,CRiskManager *risk,CLogger *logger,const double max_spread_pips,const bool one_trade_per_bar)
+     {
+      m_symbol=symbol;
+      m_risk=risk;
+      m_logger=logger;
+      m_max_spread_pips=max_spread_pips;
+      m_one_trade_per_bar=one_trade_per_bar;
+      m_trade.SetTypeFillingBySymbol(symbol);
+      m_trade.SetExpertMagicNumber(0);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Determine if trading allowed considering spread and slippage     |
+   //+------------------------------------------------------------------+
+   bool IsTradableSpread()
+     {
+      double pip=Utils::PipSize(m_symbol);
+      if(pip<=0.0)
+         return(false);
+      long spread_points=0;
+      if(!SymbolInfoInteger(m_symbol,SYMBOL_SPREAD,spread_points))
+         return(false);
+      double spread_pips=(spread_points*SymbolInfoDouble(m_symbol,SYMBOL_POINT))/pip;
+      if(spread_pips>m_max_spread_pips)
+        {
+         if(m_logger!=NULL)
+            m_logger.Warn("TradeManager","Spread too high",DoubleToString(spread_pips,1));
+         return(false);
+        }
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Submit order based on signal                                     |
+   //+------------------------------------------------------------------+
+   bool Execute(const TradeSignal &signal,const double sl_mult,const double trail_mult,const bool use_trailing,const ulong magic)
+     {
+      if(signal.direction==SIGNAL_NONE)
+         return(false);
+
+      if(!IsTradableSpread())
+         return(false);
+
+      if(m_risk==NULL || !m_risk->CanOpenPosition())
+         return(false);
+
+      datetime bar_time=iTime(m_symbol,_Period,0);
+      if(m_one_trade_per_bar && m_last_trade_bar_time==bar_time)
+        {
+         if(m_logger!=NULL)
+            m_logger.Warn("TradeManager","One-trade-per-bar active");
+         return(false);
+        }
+
+      double market_price=(signal.direction==SIGNAL_LONG)?SymbolInfoDouble(m_symbol,SYMBOL_ASK):SymbolInfoDouble(m_symbol,SYMBOL_BID);
+      if(market_price<=0.0)
+        {
+         if(m_logger!=NULL)
+            m_logger.Error("TradeManager","Invalid market price");
+         return(false);
+        }
+
+      double stop_distance=MathAbs(market_price-signal.stop_price);
+      double point=SymbolInfoDouble(m_symbol,SYMBOL_POINT);
+      if(point<=0.0)
+         return(false);
+      double stop_distance_points=stop_distance/point;
+      double volume=m_risk->CalculateVolume(stop_distance_points);
+      if(volume<=0.0)
+        {
+         if(m_logger!=NULL)
+            m_logger.Error("TradeManager","Volume calculation failed");
+         return(false);
+        }
+
+      double margin_required=0.0;
+      ENUM_ORDER_TYPE order_type=(signal.direction==SIGNAL_LONG)?ORDER_TYPE_BUY:ORDER_TYPE_SELL;
+      ResetLastError();
+      if(!OrderCalcMargin(order_type,m_symbol,volume,market_price,margin_required))
+        {
+         if(m_logger!=NULL)
+            m_logger.Error("TradeManager","OrderCalcMargin failed",IntegerToString((int)_LastError));
+         return(false);
+        }
+      double margin_free=AccountInfoDouble(ACCOUNT_MARGIN_FREE);
+      if(margin_required>margin_free)
+        {
+         if(m_logger!=NULL)
+            m_logger.Warn("TradeManager","Insufficient margin",DoubleToString(margin_required,2));
+         return(false);
+        }
+
+      m_trade.SetExpertMagicNumber((int)magic);
+
+      bool result=false;
+      long digits=0;
+      SymbolInfoInteger(m_symbol,SYMBOL_DIGITS,digits);
+      double normalized_sl=NormalizeDouble(signal.stop_price,(int)digits);
+      double normalized_tp=NormalizeDouble(signal.target_price,(int)digits);
+      string comment=(signal.direction==SIGNAL_LONG)?"USDJPY Trend Long":"USDJPY Trend Short";
+
+      if(signal.direction==SIGNAL_LONG)
+         result=m_trade.Buy(volume,m_symbol,0.0,normalized_sl,normalized_tp,comment);
+      else if(signal.direction==SIGNAL_SHORT)
+         result=m_trade.Sell(volume,m_symbol,0.0,normalized_sl,normalized_tp,comment);
+
+      long retcode=m_trade.ResultRetcode();
+      if(!result)
+        {
+         if(m_logger!=NULL)
+            m_logger.Error("TradeManager","Order send failed",IntegerToString((int)retcode));
+         return(false);
+        }
+
+      if(retcode!=TRADE_RETCODE_DONE && retcode!=TRADE_RETCODE_DONE_PARTIAL)
+        {
+         if(m_logger!=NULL)
+            m_logger.Error("TradeManager","Unexpected retcode",IntegerToString((int)retcode));
+         return(false);
+        }
+
+      if(m_logger!=NULL)
+         m_logger.Info("TradeManager","Order placed",DoubleToString(volume,2));
+
+      m_last_trade_bar_time=bar_time;
+      return(true);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Update trailing stop based on ATR                                |
+   //+------------------------------------------------------------------+
+   void UpdateTrailing(const double atr_value,const double trail_mult,const ulong magic)
+     {
+      if(atr_value<=0.0)
+         return;
+
+      double trail_distance=atr_value*trail_mult;
+      for(int i=PositionsTotal()-1;i>=0;i--)
+        {
+         if(!PositionSelectByIndex(i))
+            continue;
+         ulong ticket=(ulong)PositionGetInteger(POSITION_TICKET);
+
+         if(PositionGetInteger(POSITION_MAGIC)!= (long)magic)
+            continue;
+
+         if(PositionGetString(POSITION_SYMBOL)!=m_symbol)
+            continue;
+
+         ENUM_POSITION_TYPE type=(ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
+         double price_current=SymbolInfoDouble(m_symbol,SYMBOL_BID);
+         if(type==POSITION_TYPE_BUY)
+            price_current=SymbolInfoDouble(m_symbol,SYMBOL_BID);
+         else if(type==POSITION_TYPE_SELL)
+            price_current=SymbolInfoDouble(m_symbol,SYMBOL_ASK);
+
+         double stop=PositionGetDouble(POSITION_SL);
+         if(type==POSITION_TYPE_BUY)
+           {
+            double new_stop=price_current-trail_distance;
+            if(new_stop>stop)
+              {
+               if(!m_trade.PositionModify(ticket,new_stop,PositionGetDouble(POSITION_TP)))
+                 {
+                  if(m_logger!=NULL)
+                     m_logger.Warn("TradeManager","Failed to trail buy",IntegerToString((int)m_trade.ResultRetcode()));
+                 }
+              }
+           }
+         else if(type==POSITION_TYPE_SELL)
+           {
+            double new_stop=price_current+trail_distance;
+            if(new_stop<stop || stop==0.0)
+              {
+               if(!m_trade.PositionModify(ticket,new_stop,PositionGetDouble(POSITION_TP)))
+                 {
+                  if(m_logger!=NULL)
+                     m_logger.Warn("TradeManager","Failed to trail sell",IntegerToString((int)m_trade.ResultRetcode()));
+                 }
+              }
+           }
+        }
+     }
+  };
+
+#endif // __TRADE_MANAGER_MQH__

--- a/mql5/EA_USDJPY/modules/Utils.mqh
+++ b/mql5/EA_USDJPY/modules/Utils.mqh
@@ -1,0 +1,100 @@
+#property strict
+
+#ifndef __UTILS_MQH__
+#define __UTILS_MQH__
+
+//+------------------------------------------------------------------+
+//| Utility namespace encapsulating helper routines                 |
+//+------------------------------------------------------------------+
+namespace Utils
+  {
+   //+------------------------------------------------------------------+
+   //| Return pip size derived from broker settings                    |
+   //+------------------------------------------------------------------+
+   double PipSize(const string symbol)
+     {
+      double point=SymbolInfoDouble(symbol,SYMBOL_POINT);
+      long   digits=0;
+      if(point<=0.0)
+         return(0.0);
+      if(!SymbolInfoInteger(symbol,SYMBOL_DIGITS,digits) || digits<=0)
+         return(0.0);
+      // For most JPY pairs one pip equals 0.01 -> 100 points when 3 decimal
+      if(digits==3 || digits==1)
+         return(point*10.0);
+      return(point);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Normalize volume according to symbol specification              |
+   //+------------------------------------------------------------------+
+   double NormalizeVolume(const string symbol,const double volume)
+     {
+      double vol_min=SymbolInfoDouble(symbol,SYMBOL_VOLUME_MIN);
+      double vol_step=SymbolInfoDouble(symbol,SYMBOL_VOLUME_STEP);
+      double vol_max=SymbolInfoDouble(symbol,SYMBOL_VOLUME_MAX);
+
+      if(vol_min<=0.0 || vol_step<=0.0)
+         return(0.0);
+
+      double normalized=MathFloor((volume-vol_min)/vol_step+0.5)*vol_step+vol_min;
+      normalized=MathMax(vol_min,MathMin(vol_max,normalized));
+
+      long volume_digits=2;
+      SymbolInfoInteger(symbol,SYMBOL_VOLUME_DIGITS,volume_digits);
+
+      return(NormalizeDouble(normalized,(int)volume_digits));
+     }
+
+   //+------------------------------------------------------------------+
+   //| Determine if server time lies inside user configured window     |
+   //+------------------------------------------------------------------+
+   bool IsWithinTimeWindow(const bool enabled,const int start_hour,const int end_hour)
+     {
+      if(!enabled)
+         return(true);
+
+      datetime now=TimeCurrent();
+      int hour=(int)TimeHour(now);
+
+      if(start_hour<=end_hour)
+         return(hour>=start_hour && hour<end_hour);
+
+      // Overnight window: e.g. 22 -> 6
+      if(hour>=start_hour || hour<end_hour)
+         return(true);
+      return(false);
+     }
+
+   //+------------------------------------------------------------------+
+   //| Helper struct storing bar state for one-trade-per-bar control   |
+   //+------------------------------------------------------------------+
+   class CBarState
+     {
+    private:
+      datetime m_last_bar_time;
+    public:
+      //+------------------------------------------------------------------+
+      //| Constructor initializes last bar time                          |
+      //+------------------------------------------------------------------+
+      CBarState():m_last_bar_time(0){}
+
+      //+------------------------------------------------------------------+
+      //| Update internal bar time and check if new bar formed            |
+      //+------------------------------------------------------------------+
+      bool IsNewBar(const string symbol,const ENUM_TIMEFRAMES tf)
+        {
+         datetime current=iTime(symbol,tf,0);
+         if(current==0)
+            return(false);
+         if(current!=m_last_bar_time)
+           {
+            m_last_bar_time=current;
+            return(true);
+           }
+         return(false);
+        }
+     };
+  }
+
+#endif // __UTILS_MQH__

--- a/mql5/EA_USDJPY/sample_log.csv
+++ b/mql5/EA_USDJPY/sample_log.csv
@@ -1,0 +1,6 @@
+timestamp,event,message,extra
+2024-03-01 08:00:01,INFO,Init,Starting EA
+2024-03-01 09:15:02,INFO,Signal,Trade executed|REGIME_TREND
+2024-03-01 10:45:00,WARN,RiskManager,Daily loss cap reached|2.10
+2024-03-01 12:30:11,INFO,Tester,Average R:R|1.35
+2024-03-01 18:59:00,ERROR,TradeManager,Order send failed|4756


### PR DESCRIPTION
## Summary
- replace invalid indicator calls with handle-based buffering and add initialization checks in the EA core
- rebuild logging and utility helpers to use supported MQL5 APIs and broker-aware symbol metadata access
- update trade and risk managers to respect stop-distance calculations, trailing, and tester return requirements

## Testing
- not run (MetaTrader 5 unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68fb292887d08333b6c7ea9a98564435